### PR TITLE
feat: add _app_start event, change user engagement attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following dependency to your `app` module's `build.gradle` file.
 
 ```groovy
 dependencies {
-    implementation 'software.aws.solution:clickstream:0.4.4'
+    implementation 'software.aws.solution:clickstream:0.5.0'
 }
 ```
 

--- a/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
@@ -143,7 +143,7 @@ final class ActivityLifecycleManager implements Application.ActivityLifecycleCal
             autoRecordEventClient.recordUserEngagement();
         } else if (event == Lifecycle.Event.ON_START) {
             LOG.debug("Application entered the foreground.");
-            autoRecordEventClient.handleFirstOpen();
+            autoRecordEventClient.handleAppStart();
             autoRecordEventClient.updateEngageTimestamp();
             boolean isNewSession = sessionClient.initialSession();
             if (isNewSession) {

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/Event.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/Event.java
@@ -269,6 +269,11 @@ public final class Event {
          */
         public static final String ENGAGEMENT_TIMESTAMP = "_engagement_time_msec";
 
+        /**
+         * is the first time attribute.
+         */
+        public static final String IS_FIRST_TIME = "_is_first_time";
+
         private ReservedAttribute() {
         }
     }
@@ -283,13 +288,14 @@ public final class Event {
         public static final String SESSION_START = "_session_start";
 
         /**
-         * The eventType recorded for session stop events.
-         */
-        public static final String SESSION_STOP = "_session_stop";
-        /**
          * The eventType recorded for app first open from install.
          */
         public static final String FIRST_OPEN = "_first_open";
+
+        /**
+         * The eventType recorded for app start when app move to foreground.
+         */
+        public static final String APP_START = "_app_start";
 
         /**
          * The user engagement event when the app is in the foreground at least one second.

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
@@ -24,6 +24,8 @@ public final class ScreenRefererTool {
     private static String mCurrentScreenId;
     private static String mPreviousScreenName;
     private static String mCurrentScreenName;
+    private static long mPreviousScreenStartTimestamp;
+    private static long mCurrentScreenStartTimestamp;
 
     private ScreenRefererTool() {
     }
@@ -46,6 +48,16 @@ public final class ScreenRefererTool {
     public static void setCurrentScreenId(String screenId) {
         mPreviousScreenId = mCurrentScreenId;
         mCurrentScreenId = screenId;
+    }
+
+    /**
+     * set current screen id.
+     *
+     * @param timestamp current screen engage timestamp.
+     */
+    public static void setCurrentScreenStartTimestamp(long timestamp) {
+        mPreviousScreenStartTimestamp = mCurrentScreenStartTimestamp;
+        mCurrentScreenStartTimestamp = timestamp;
     }
 
     /**
@@ -82,5 +94,14 @@ public final class ScreenRefererTool {
      */
     public static String getPreviousScreenId() {
         return mPreviousScreenId;
+    }
+
+    /**
+     * get previous screen start timestamp.
+     *
+     * @return previous screen start timestamp
+     */
+    public static long getPreviousScreenStartTimestamp() {
+        return mPreviousScreenStartTimestamp;
     }
 }

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/network/NetRequest.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/network/NetRequest.java
@@ -106,7 +106,7 @@ public final class NetRequest {
         RequestBody body = RequestBody.create(curStr, MediaType.parse("application/json; charset=utf-8"));
         Request request = new Request.Builder().url(endpoint).build();
         HttpUrl url = request.url().newBuilder()
-            .addQueryParameter("platform", "ANDROID")
+            .addQueryParameter("platform", "Android")
             .addQueryParameter("appId", appId)
             .addQueryParameter("event_bundle_sequence_id", String.valueOf(bundleSequenceId))
             .addQueryParameter("compression", compression)

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/system/AndroidDeviceDetails.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/system/AndroidDeviceDetails.java
@@ -59,7 +59,7 @@ public class AndroidDeviceDetails {
      * @return The name of platform.
      */
     public String platform() {
-        return "ANDROID";
+        return "Android";
     }
 
     /**

--- a/clickstream/src/test/java/software/aws/solution/clickstream/ActivityLifecycleManagerUnitTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/ActivityLifecycleManagerUnitTest.java
@@ -117,7 +117,7 @@ public final class ActivityLifecycleManagerUnitTest {
         when(sessionClient.initialSession()).thenReturn(true);
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
         verify(autoRecordEventClient).updateEngageTimestamp();
-        verify(autoRecordEventClient).handleFirstOpen();
+        verify(autoRecordEventClient).handleAppStart();
         verify(sessionClient).initialSession();
         verify(autoRecordEventClient).setIsEntrances();
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx4g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-VERSION_NAME=0.4.4
+VERSION_NAME=0.5.0
 
 POM_GROUP=software.aws.solution
 POM_ARTIFACT_ID=clickstream


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. add _app_start preset event when app move to foreground.
2. change _screen_view event user engagement time attribute to previous screen's engagement time.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.