### PR TITLE
fix: change user engagement event and engagement time calculate rule

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
+import software.aws.solution.clickstream.client.system.AndroidPreferences;
+import software.aws.solution.clickstream.client.util.PreferencesUtil;
 import software.aws.solution.clickstream.client.util.StringUtil;
 
 /**
@@ -31,6 +33,7 @@ public class AutoRecordEventClient {
      */
     private static final Log LOG = LogFactory.getLog(AutoRecordEventClient.class);
     private static final int MIN_ENGAGEMENT_TIME = 1000;
+    private static final int DEVICE_ID_CLIP_LENGTH = 8;
     /**
      * The context object wraps all the essential information from the app
      * that are required.
@@ -53,6 +56,9 @@ public class AutoRecordEventClient {
     private boolean isEntrances;
 
     private long startEngageTimestamp;
+    private long endEngageTimestamp;
+    private long lastEngageTime;
+    private final AndroidPreferences preferences;
 
     /**
      * CONSTRUCTOR.
@@ -65,7 +71,8 @@ public class AutoRecordEventClient {
             throw new IllegalArgumentException("A valid AnalyticsClient must be provided!");
         }
         this.clickstreamContext = clickstreamContext;
-        this.isFirstOpen = clickstreamContext.getSystem().getPreferences().getBoolean("isFirstOpen", true);
+        this.preferences = clickstreamContext.getSystem().getPreferences();
+        this.isFirstOpen = preferences.getBoolean("isFirstOpen", true);
     }
 
     /**
@@ -79,55 +86,81 @@ public class AutoRecordEventClient {
         }
         String screenId = activity.getClass().getCanonicalName();
         String screenName = activity.getClass().getSimpleName();
-        long currentTimestamp = System.currentTimeMillis();
+        String screenUniqueId = getScreenUniqueId(activity);
+        if (ScreenRefererTool.isSameScreen(screenId, screenName, screenUniqueId)) {
+            return;
+        }
         ScreenRefererTool.setCurrentScreenId(screenId);
         ScreenRefererTool.setCurrentScreenName(screenName);
-        ScreenRefererTool.setCurrentScreenStartTimestamp(currentTimestamp);
+        ScreenRefererTool.setCurrentScreenUniqueId(screenUniqueId);
         final AnalyticsEvent event =
             this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.SCREEN_VIEW);
+        long currentTimestamp = event.getEventTimestamp();
+        startEngageTimestamp = currentTimestamp;
         event.addAttribute(Event.ReservedAttribute.SCREEN_NAME, ScreenRefererTool.getCurrentScreenName());
         event.addAttribute(Event.ReservedAttribute.SCREEN_ID, ScreenRefererTool.getCurrentScreenId());
+        event.addAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID, ScreenRefererTool.getCurrentScreenUniqueId());
         event.addAttribute(Event.ReservedAttribute.PREVIOUS_SCREEN_NAME, ScreenRefererTool.getPreviousScreenName());
         event.addAttribute(Event.ReservedAttribute.PREVIOUS_SCREEN_ID, ScreenRefererTool.getPreviousScreenId());
-        event.addAttribute(Event.ReservedAttribute.ENTRANCES, isEntrances ? 1 : 0);
-        if (!isEntrances) {
-            event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP,
-                currentTimestamp - ScreenRefererTool.getPreviousScreenStartTimestamp());
+        event.addAttribute(Event.ReservedAttribute.PREVIOUS_SCREEN_UNIQUE_ID,
+            ScreenRefererTool.getPreviousScreenUniqueId());
+        long lastScreenViewEventTimestamp = PreferencesUtil.getPreviousScreenViewTimestamp(preferences);
+        if (lastScreenViewEventTimestamp > 0) {
+            event.addAttribute(Event.ReservedAttribute.PREVIOUS_TIMESTAMP, lastScreenViewEventTimestamp);
         }
+        event.addAttribute(Event.ReservedAttribute.ENTRANCES, isEntrances ? 1 : 0);
+        event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP, lastEngageTime);
         this.clickstreamContext.getAnalyticsClient().recordEvent(event);
+        PreferencesUtil.savePreviousScreenViewTimestamp(preferences, currentTimestamp);
         isEntrances = false;
         LOG.debug("record an _screen_view event, screenId:" + screenId + "lastScreenId:" +
             ScreenRefererTool.getPreviousScreenId());
+    }
+
+    public String getScreenUniqueId(Activity activity) {
+        String clipDeviceId = StringUtil.trimOrPadString(clickstreamContext.getDeviceId(), DEVICE_ID_CLIP_LENGTH, '_');
+        return clipDeviceId + "_" + activity.hashCode();
     }
 
     /**
      * record user engagement event.
      */
     public void recordUserEngagement() {
-        long engagementTime = System.currentTimeMillis() - startEngageTimestamp;
-        if (engagementTime > MIN_ENGAGEMENT_TIME) {
+        lastEngageTime = endEngageTimestamp - startEngageTimestamp;
+        if (lastEngageTime > MIN_ENGAGEMENT_TIME) {
             final AnalyticsEvent event =
                 this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.USER_ENGAGEMENT);
-            event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP, engagementTime);
+            event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP, lastEngageTime);
             event.addAttribute(Event.ReservedAttribute.SCREEN_NAME, ScreenRefererTool.getCurrentScreenName());
             event.addAttribute(Event.ReservedAttribute.SCREEN_ID, ScreenRefererTool.getCurrentScreenId());
+            event.addAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID, ScreenRefererTool.getCurrentScreenUniqueId());
             this.clickstreamContext.getAnalyticsClient().recordEvent(event);
         }
+    }
+
+    public void flushEvents() {
         this.clickstreamContext.getAnalyticsClient().submitEvents();
     }
 
     /**
-     * update engage timestamp.
+     * update start engage timestamp.
      */
-    public void updateEngageTimestamp() {
+    public void updateStartEngageTimestamp() {
         startEngageTimestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * update end engage timestamp.
+     */
+    public void updateEndEngageTimestamp() {
+        endEngageTimestamp = System.currentTimeMillis();
     }
 
     /**
      * check and record _app_update event.
      */
     private void checkAppVersionUpdate() {
-        String previousAppVersion = clickstreamContext.getSystem().getPreferences().getString("appVersion", "");
+        String previousAppVersion = preferences.getString("appVersion", "");
         if (!StringUtil.isNullOrEmpty(previousAppVersion)) {
             String currentVersion = clickstreamContext.getSystem().getAppDetails().versionName();
             if (!currentVersion.equals(previousAppVersion)) {
@@ -135,11 +168,10 @@ public class AutoRecordEventClient {
                     this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.APP_UPDATE);
                 event.addAttribute(Event.ReservedAttribute.PREVIOUS_APP_VERSION, previousAppVersion);
                 this.clickstreamContext.getAnalyticsClient().recordEvent(event);
-                clickstreamContext.getSystem().getPreferences().putString("appVersion", currentVersion);
+                preferences.putString("appVersion", currentVersion);
             }
         } else {
-            clickstreamContext.getSystem().getPreferences()
-                .putString("appVersion", clickstreamContext.getSystem().getAppDetails().versionName());
+            preferences.putString("appVersion", clickstreamContext.getSystem().getAppDetails().versionName());
         }
     }
 
@@ -147,7 +179,7 @@ public class AutoRecordEventClient {
      * check and record _os_update event.
      */
     private void checkOSVersionUpdate() {
-        String previousOSVersion = clickstreamContext.getSystem().getPreferences().getString("osVersion", "");
+        String previousOSVersion = preferences.getString("osVersion", "");
         if (!StringUtil.isNullOrEmpty(previousOSVersion)) {
             String currentOSVersion = clickstreamContext.getSystem().getDeviceDetails().platformVersion();
             if (!currentOSVersion.equals(previousOSVersion)) {
@@ -155,11 +187,10 @@ public class AutoRecordEventClient {
                     this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.OS_UPDATE);
                 event.addAttribute(Event.ReservedAttribute.PREVIOUS_OS_VERSION, previousOSVersion);
                 this.clickstreamContext.getAnalyticsClient().recordEvent(event);
-                clickstreamContext.getSystem().getPreferences().putString("osVersion", currentOSVersion);
+                preferences.putString("osVersion", currentOSVersion);
             }
         } else {
-            clickstreamContext.getSystem().getPreferences()
-                .putString("osVersion", clickstreamContext.getSystem().getDeviceDetails().platformVersion());
+            preferences.putString("osVersion", clickstreamContext.getSystem().getDeviceDetails().platformVersion());
         }
     }
 
@@ -173,7 +204,7 @@ public class AutoRecordEventClient {
             final AnalyticsEvent event =
                 this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.FIRST_OPEN);
             this.clickstreamContext.getAnalyticsClient().recordEvent(event);
-            clickstreamContext.getSystem().getPreferences().putBoolean("isFirstOpen", false);
+            preferences.putBoolean("isFirstOpen", false);
             isFirstOpen = false;
         }
         final AnalyticsEvent event =

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -117,6 +117,13 @@ public class AutoRecordEventClient {
             ScreenRefererTool.getPreviousScreenId());
     }
 
+    /**
+     * get the screen unique id for activity.
+     * the unique id calculated by appending the last 8 characters of the device id with "_" and the activity hash code.
+     *
+     * @param activity the activity for holding the screen
+     * @return the unique of the activity
+     */
     public String getScreenUniqueId(Activity activity) {
         String clipDeviceId = StringUtil.trimOrPadString(clickstreamContext.getDeviceId(), DEVICE_ID_CLIP_LENGTH, '_');
         return clipDeviceId + "_" + activity.hashCode();
@@ -138,6 +145,9 @@ public class AutoRecordEventClient {
         }
     }
 
+    /**
+     * the method for flush events when app move to background.
+     */
     public void flushEvents() {
         this.clickstreamContext.getAnalyticsClient().submitEvents();
     }

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/Event.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/Event.java
@@ -243,6 +243,11 @@ public final class Event {
          * screen id.
          */
         public static final String SCREEN_ID = "_screen_id";
+
+        /**
+         * screen unique id.
+         */
+        public static final String SCREEN_UNIQUE_ID = "_screen_unique_id";
         /**
          * previous screen name.
          */
@@ -251,6 +256,15 @@ public final class Event {
          * previous screen id.
          */
         public static final String PREVIOUS_SCREEN_ID = "_previous_screen_id";
+
+        /**
+         * previous screen unique id.
+         */
+        public static final String PREVIOUS_SCREEN_UNIQUE_ID = "_previous_screen_unique_id";
+        /**
+         * previous event timestamp.
+         */
+        public static final String PREVIOUS_TIMESTAMP = "_previous_timestamp";
         /**
          * entrances.
          */

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
@@ -24,8 +24,8 @@ public final class ScreenRefererTool {
     private static String mCurrentScreenId;
     private static String mPreviousScreenName;
     private static String mCurrentScreenName;
-    private static long mPreviousScreenStartTimestamp;
-    private static long mCurrentScreenStartTimestamp;
+    private static String mPreviousScreenUniqueId;
+    private static String mCurrentScreenUniqueId;
 
     private ScreenRefererTool() {
     }
@@ -51,13 +51,13 @@ public final class ScreenRefererTool {
     }
 
     /**
-     * set current screen id.
+     * set current screen unique id.
      *
-     * @param timestamp current screen engage timestamp.
+     * @param screenUniqueId current screen unique id to set.
      */
-    public static void setCurrentScreenStartTimestamp(long timestamp) {
-        mPreviousScreenStartTimestamp = mCurrentScreenStartTimestamp;
-        mCurrentScreenStartTimestamp = timestamp;
+    public static void setCurrentScreenUniqueId(String screenUniqueId) {
+        mPreviousScreenUniqueId = mCurrentScreenUniqueId;
+        mCurrentScreenUniqueId = screenUniqueId;
     }
 
     /**
@@ -79,6 +79,16 @@ public final class ScreenRefererTool {
     }
 
     /**
+     * get current screen unique id.
+     *
+     * @return mCurrentScreenUniqueId
+     */
+    public static String getCurrentScreenUniqueId() {
+        return mCurrentScreenUniqueId;
+    }
+
+
+    /**
      * get previous ScreenName.
      *
      * @return mPreviousScreenName
@@ -97,11 +107,27 @@ public final class ScreenRefererTool {
     }
 
     /**
-     * get previous screen start timestamp.
+     * get previous screen unique id.
      *
-     * @return previous screen start timestamp
+     * @return mPreviousScreenUniqueId
      */
-    public static long getPreviousScreenStartTimestamp() {
-        return mPreviousScreenStartTimestamp;
+    public static String getPreviousScreenUniqueId() {
+        return mPreviousScreenUniqueId;
+    }
+
+    /**
+     * Judging that the current screen is the same as the previous screen.
+     *
+     * @param screenId       current screen id
+     * @param screenName     current screen name
+     * @param screenUniqueId current screen unique id
+     * @return the boolean value for is the same screen
+     */
+    public static boolean isSameScreen(String screenId, String screenName, String screenUniqueId) {
+        return mCurrentScreenId != null
+            && mCurrentScreenName != null
+            && mCurrentScreenId.equals(screenId)
+            && mCurrentScreenName.equals(screenName)
+            && mCurrentScreenUniqueId.equals(screenUniqueId);
     }
 }

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
@@ -87,7 +87,6 @@ public final class ScreenRefererTool {
         return mCurrentScreenUniqueId;
     }
 
-
     /**
      * get previous ScreenName.
      *

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/util/PreferencesUtil.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/util/PreferencesUtil.java
@@ -36,7 +36,7 @@ public final class PreferencesUtil {
     private static final String CURRENT_USER_UNIQUE_ID = "clickstream_current_user_unique_id";
     private static final String CURRENT_USER_FIRST_TOUCH_TIMESTAMP = "clickstream_current_user_first_touch_timestamp";
     private static final String CURRENT_SESSION = "clickstream_current_session";
-    private static final String ENGAGEMENT_START_TIMESTAMP = "clickstream_engagement_start_timestamp";
+    private static final String PREVIOUS_SCREEN_VIEW_TIMESTAMP = "clickstream_previous_screen_view_timestamp";
 
     /**
      * Default constructor.
@@ -164,8 +164,7 @@ public final class PreferencesUtil {
             userAttribute.putOpt(Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP, attribute);
             updateUserAttribute(preferences, userAttribute);
         } catch (JSONException exception) {
-            LOG.error(
-                "Could not create Json object of user first touch timestamp. error: " + exception.getMessage());
+            LOG.error("Could not create Json object of user first touch timestamp. error: " + exception.getMessage());
         }
     }
 
@@ -234,13 +233,23 @@ public final class PreferencesUtil {
     }
 
     /**
-     * get engagement start timestamp.
+     * get last screen view start timestamp.
      *
      * @param preferences AndroidPreferences
-     * @return engagement start timestamp
+     * @return last screen view start timestamp
      */
-    public static long getEngageStartTimestamp(final AndroidPreferences preferences) {
-        return preferences.getLong(ENGAGEMENT_START_TIMESTAMP, 0);
+    public static long getPreviousScreenViewTimestamp(final AndroidPreferences preferences) {
+        return preferences.getLong(PREVIOUS_SCREEN_VIEW_TIMESTAMP, 0);
+    }
+
+    /**
+     * set last screen view start timestamp.
+     *
+     * @param preferences AndroidPreferences
+     * @param timestamp   the last screen view start time stamp
+     */
+    public static void savePreviousScreenViewTimestamp(final AndroidPreferences preferences, long timestamp) {
+        preferences.putLong(PREVIOUS_SCREEN_VIEW_TIMESTAMP, timestamp);
     }
 
 }

--- a/clickstream/src/test/java/software/aws/solution/clickstream/ActivityLifecycleManagerUnitTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/ActivityLifecycleManagerUnitTest.java
@@ -123,7 +123,7 @@ public final class ActivityLifecycleManagerUnitTest {
     public void testOnAppForegrounded() {
         when(sessionClient.initialSession()).thenReturn(true);
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-        verify(autoRecordEventClient).updateEngageTimestamp();
+        verify(autoRecordEventClient).updateStartEngageTimestamp();
         verify(autoRecordEventClient).handleAppStart();
         verify(sessionClient).initialSession();
         verify(autoRecordEventClient).setIsEntrances();

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -252,7 +252,7 @@ public class AutoRecordEventClientTest {
     }
 
     /**
-     * test view two same screen and record one screen view event
+     * test view two same screen and record one screen view event.
      *
      * @throws Exception exception.
      */
@@ -285,7 +285,7 @@ public class AutoRecordEventClientTest {
     }
 
     /**
-     * test view same screen twice and only record the last screen view engagement_time_msec
+     * test view same screen twice and only record the last screen view engagement_time_msec.
      *
      * @throws Exception exception.
      */
@@ -300,7 +300,6 @@ public class AutoRecordEventClientTest {
         callbacks.onActivityResumed(activityA);
         Thread.sleep(200);
         callbacks.onActivityPaused(activityA);
-
 
         callbacks.onActivityCreated(activityA, bundle);
         callbacks.onActivityStarted(activityA);
@@ -366,7 +365,7 @@ public class AutoRecordEventClientTest {
     }
 
     /**
-     * test previous timestamp is setting correct in screen events
+     * test previous timestamp is setting correct in screen events.
      *
      * @throws Exception exception.
      */


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. Change the user engagement event definition to: Calculate an engagement event for each screen leave.
2. Changes the screen view engage time to the engage time of the previous user engagement event.

*How did you test these changes?*
added test case for different scenarios. 

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.