### PR TITLE
feat: add error code and clickstream error event

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/AWSClickstreamPlugin.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/AWSClickstreamPlugin.java
@@ -98,7 +98,7 @@ public final class AWSClickstreamPlugin extends AnalyticsPlugin<Object> {
         final AnalyticsEvent clickstreamEvent =
             analyticsClient.createEvent(analyticsEvent.getName());
 
-        if (analyticsEvent.getProperties() != null) {
+        if (clickstreamEvent != null && analyticsEvent.getProperties() != null) {
             for (Map.Entry<String, AnalyticsPropertyBehavior<?>> entry : analyticsEvent.getProperties()) {
                 AnalyticsPropertyBehavior<?> property = entry.getValue();
                 clickstreamEvent.addAttribute(entry.getKey(), property.getValue());

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AnalyticsEvent.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AnalyticsEvent.java
@@ -252,8 +252,9 @@ public class AnalyticsEvent implements JSONSerializable {
             Event.EventError attributeError = Event.checkAttribute(getCurrentNumOfAttributes(), name, value);
             try {
                 if (attributeError != null) {
-                    if (!attributes.has(attributeError.getErrorType())) {
-                        attributes.putOpt(attributeError.getErrorType(), attributeError.getErrorMessage());
+                    if (!attributes.has(Event.ReservedAttribute.ERROR_CODE)) {
+                        attributes.putOpt(Event.ReservedAttribute.ERROR_CODE, attributeError.getErrorCode());
+                        attributes.putOpt(Event.ReservedAttribute.ERROR_MESSAGE, attributeError.getErrorMessage());
                     }
                 } else {
                     attributes.putOpt(name, value);

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/Event.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/Event.java
@@ -31,6 +31,25 @@ public final class Event {
     }
 
     /**
+     * check the event type.
+     *
+     * @param eventName the event name
+     * @return the EventError object
+     */
+    public static EventError checkEventName(String eventName) {
+        if (!isValidName(eventName)) {
+            return new EventError(ErrorCode.EVENT_NAME_INVALID,
+                "Event name can only contains uppercase and lowercase letters, " +
+                    "underscores, number, and is not start with a number. event name: " + eventName);
+        } else if (eventName.length() > Limit.MAX_LENGTH_OF_NAME) {
+            return new EventError(ErrorCode.EVENT_NAME_LENGTH_EXCEED,
+                "Event name is too long, the max event type length is " +
+                    Limit.MAX_LENGTH_OF_NAME + "characters. event name: " + eventName);
+        }
+        return null;
+    }
+
+    /**
      * check the attribute error.
      *
      * @param currentNumber current attribute number
@@ -42,14 +61,14 @@ public final class Event {
         if (currentNumber >= Limit.MAX_NUM_OF_ATTRIBUTES) {
             LOG.error("reached the max number of attributes limit ("
                 + Limit.MAX_NUM_OF_ATTRIBUTES + "). and the attribute: " + name + " will not be recorded");
-            return new EventError(ErrorType.ATTRIBUTE_SIZE_EXCEED,
+            return new EventError(ErrorCode.ATTRIBUTE_SIZE_EXCEED,
                 StringUtil.clipString("attribute name: " + name, Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
         }
         if (name.length() > Limit.MAX_LENGTH_OF_NAME) {
             LOG.error("attribute : " + name + ", reached the max length of attributes name limit("
                 + Limit.MAX_LENGTH_OF_NAME + "). current length is:(" + name.length() +
                 ") and the attribute will not be recorded");
-            return new EventError(ErrorType.ATTRIBUTE_NAME_LENGTH_EXCEED,
+            return new EventError(ErrorCode.ATTRIBUTE_NAME_LENGTH_EXCEED,
                 StringUtil.clipString("attribute name length is:(" + name.length() + ") name is:" + name,
                     Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
         }
@@ -57,7 +76,7 @@ public final class Event {
             LOG.error("attribute : " + name + ", was not valid, attribute name can only contains" +
                 " uppercase and lowercase letters, underscores, number, and is not start with a number." +
                 " so the attribute will not be recorded");
-            return new EventError(ErrorType.ATTRIBUTE_NAME_INVALID,
+            return new EventError(ErrorCode.ATTRIBUTE_NAME_INVALID,
                 StringUtil.clipString(name, Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
         }
 
@@ -68,7 +87,7 @@ public final class Event {
                     + Limit.MAX_LENGTH_OF_VALUE + "). current length is:(" + valueLength +
                     "). and the attribute will not be recorded, attribute value:" + value);
 
-                return new EventError(ErrorType.ATTRIBUTE_VALUE_LENGTH_EXCEED,
+                return new EventError(ErrorCode.ATTRIBUTE_VALUE_LENGTH_EXCEED,
                     StringUtil.clipString("attribute name:" + name + ", attribute value:" + value,
                         Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
             }
@@ -88,14 +107,14 @@ public final class Event {
         if (currentNumber >= Limit.MAX_NUM_OF_USER_ATTRIBUTES) {
             LOG.error("reached the max number of user attributes limit ("
                 + Limit.MAX_NUM_OF_USER_ATTRIBUTES + "). and the user attribute: " + name + " will not be recorded");
-            return new EventError(ErrorType.ATTRIBUTE_SIZE_EXCEED,
+            return new EventError(ErrorCode.USER_ATTRIBUTE_SIZE_EXCEED,
                 StringUtil.clipString("attribute name: " + name, Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
         }
         if (name.length() > Limit.MAX_LENGTH_OF_NAME) {
             LOG.error("user attribute : " + name + ", reached the max length of attributes name limit("
                 + Limit.MAX_LENGTH_OF_NAME + "). current length is:(" + name.length() +
                 ") and the attribute will not be recorded");
-            return new EventError(ErrorType.ATTRIBUTE_NAME_LENGTH_EXCEED,
+            return new EventError(ErrorCode.USER_ATTRIBUTE_NAME_LENGTH_EXCEED,
                 StringUtil.clipString("user attribute name length is:(" + name.length() + ") name is:" + name,
                     Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
         }
@@ -106,7 +125,7 @@ public final class Event {
             LOG.error("user attribute : " + name + ", was not valid, user attribute name can only contains" +
                 " uppercase and lowercase letters, underscores, number, and is not start with a number." +
                 " so the attribute will not be recorded");
-            return new EventError(ErrorType.ATTRIBUTE_NAME_INVALID,
+            return new EventError(ErrorCode.USER_ATTRIBUTE_NAME_INVALID,
                 StringUtil.clipString(name, Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
         }
         if (value instanceof String) {
@@ -115,7 +134,7 @@ public final class Event {
                 LOG.error("user attribute : " + name + ", reached the max length of attributes value limit ("
                     + Limit.MAX_LENGTH_OF_USER_VALUE + "). current length is:(" + valueLength +
                     "). and the attribute will not be recorded, attribute value:" + value);
-                return new EventError(ErrorType.ATTRIBUTE_VALUE_LENGTH_EXCEED,
+                return new EventError(ErrorCode.USER_ATTRIBUTE_VALUE_LENGTH_EXCEED,
                     StringUtil.clipString("user attribute name:" + name + ", attribute value:" + value,
                         Limit.MAX_LENGTH_OF_ERROR_VALUE, true));
             }
@@ -173,15 +192,51 @@ public final class Event {
     }
 
     /**
-     * event error type.
+     * the event error code constants.
      */
-    public static final class ErrorType {
-        private static final String ATTRIBUTE_NAME_INVALID = "_error_name_invalid";
-        private static final String ATTRIBUTE_NAME_LENGTH_EXCEED = "_error_name_length_exceed";
-        private static final String ATTRIBUTE_VALUE_LENGTH_EXCEED = "_error_value_length_exceed";
-        private static final String ATTRIBUTE_SIZE_EXCEED = "_error_attribute_size_exceed";
+    public static final class ErrorCode {
+        /**
+         * error code for event name invalid.
+         */
+        public static final int EVENT_NAME_INVALID = 1001;
+        /**
+         * error code for event name length exceed the limit.
+         */
+        public static final int EVENT_NAME_LENGTH_EXCEED = 1002;
+        /**
+         * error code for attribute name length exceed.
+         */
+        public static final int ATTRIBUTE_NAME_LENGTH_EXCEED = 2001;
+        /**
+         * error code for attribute name invalid.
+         */
+        public static final int ATTRIBUTE_NAME_INVALID = 2002;
+        /**
+         * error code for attribute value length exceed.
+         */
+        public static final int ATTRIBUTE_VALUE_LENGTH_EXCEED = 2003;
+        /**
+         * error code for attribute size exceed.
+         */
+        public static final int ATTRIBUTE_SIZE_EXCEED = 2004;
+        /**
+         * error code for user attribute size exceed.
+         */
+        public static final int USER_ATTRIBUTE_SIZE_EXCEED = 3001;
+        /**
+         * error code for user attribute name length exceed.
+         */
+        public static final int USER_ATTRIBUTE_NAME_LENGTH_EXCEED = 3002;
+        /**
+         * error code for user user attribute name invalid.
+         */
+        public static final int USER_ATTRIBUTE_NAME_INVALID = 3003;
+        /**
+         * error code for user attribute value length exceed.
+         */
+        public static final int USER_ATTRIBUTE_VALUE_LENGTH_EXCEED = 3004;
 
-        private ErrorType() {
+        private ErrorCode() {
         }
     }
 
@@ -189,11 +244,11 @@ public final class Event {
      * Event for return.
      */
     public static class EventError {
-        private final String errorType;
+        private final int errorCode;
         private final String errorMessage;
 
-        EventError(String errorType, String errorMessage) {
-            this.errorType = errorType;
+        EventError(int errorType, String errorMessage) {
+            this.errorCode = errorType;
             this.errorMessage = errorMessage;
         }
 
@@ -202,8 +257,8 @@ public final class Event {
          *
          * @return error type
          */
-        public String getErrorType() {
-            return errorType;
+        public int getErrorCode() {
+            return errorCode;
         }
 
         /**
@@ -287,6 +342,14 @@ public final class Event {
          * is the first time attribute.
          */
         public static final String IS_FIRST_TIME = "_is_first_time";
+        /**
+         * is the error code attribute.
+         */
+        public static final String ERROR_CODE = "_error_code";
+        /**
+         * is the error message attribute.
+         */
+        public static final String ERROR_MESSAGE = "_error_message";
 
         private ReservedAttribute() {
         }
@@ -345,6 +408,11 @@ public final class Event {
          * profile set event for user attribute changes.
          */
         public static final String PROFILE_SET = "_profile_set";
+
+        /**
+         * clickstream error event.
+         */
+        public static final String CLICKSTREAM_ERROR = "_clickstream_error";
 
         private PresetEvent() {
         }

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AnalyticsEventTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AnalyticsEventTest.java
@@ -29,6 +29,7 @@ import org.robolectric.annotation.Config;
 import software.aws.solution.clickstream.client.AnalyticsClient;
 import software.aws.solution.clickstream.client.AnalyticsEvent;
 import software.aws.solution.clickstream.client.ClickstreamManager;
+import software.aws.solution.clickstream.client.Event;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -93,9 +94,11 @@ public class AnalyticsEventTest {
 
     /**
      * test the event attribute reach the limit.
+     *
+     * @throws JSONException the json exception
      */
     @Test
-    public void eventAttributeReachLimit() {
+    public void eventAttributeReachLimit() throws JSONException {
         AnalyticsEvent event = analyticsClient.createEvent("testEvent");
         for (int i = 1; i < 502; i++) {
             event.addAttribute("name" + i, "value" + i);
@@ -104,9 +107,9 @@ public class AnalyticsEventTest {
         Assert.assertEquals(event.getStringAttribute("name11"), "value11");
         Assert.assertEquals(event.getStringAttribute("name500"), "value500");
         Assert.assertNull(event.getStringAttribute("name501"));
-        Assert.assertEquals(event.getCurrentNumOfAttributes(), 501);
-        Assert.assertTrue(event.hasAttribute("_error_attribute_size_exceed"));
-        Assert.assertNotNull(event.getStringAttribute("_error_attribute_size_exceed"));
+        Assert.assertEquals(502, event.getCurrentNumOfAttributes());
+        Assert.assertEquals(Event.ErrorCode.ATTRIBUTE_SIZE_EXCEED,
+            event.getAttributes().get(Event.ReservedAttribute.ERROR_CODE));
     }
 
     /**

--- a/clickstream/src/test/java/software/aws/solution/clickstream/EventRecorderTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/EventRecorderTest.java
@@ -24,6 +24,7 @@ import com.amazonaws.logging.Log;
 import com.github.dreamhead.moco.HttpServer;
 import com.github.dreamhead.moco.Runner;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,6 +39,7 @@ import software.aws.solution.clickstream.client.AnalyticsEvent;
 import software.aws.solution.clickstream.client.ClickstreamConfiguration;
 import software.aws.solution.clickstream.client.ClickstreamContext;
 import software.aws.solution.clickstream.client.ClickstreamManager;
+import software.aws.solution.clickstream.client.Event;
 import software.aws.solution.clickstream.client.EventRecorder;
 import software.aws.solution.clickstream.client.db.ClickstreamDBUtil;
 import software.aws.solution.clickstream.util.ReflectUtil;
@@ -162,16 +164,18 @@ public class EventRecorderTest {
 
     /**
      * test insert single event when exceed attribute number limit.
+     * @throws JSONException the json exception
      */
     @Test
-    public void testRecordEventExceedAttributeNumberLimit() {
+    public void testRecordEventExceedAttributeNumberLimit() throws JSONException {
         for (int i = 0; i < 501; i++) {
             event.addAttribute("name" + i, "value" + i);
         }
         assertEquals("value499", event.getStringAttribute("name499"));
         assertFalse(event.hasAttribute("name500"));
-        assertTrue(event.hasAttribute("_error_attribute_size_exceed"));
-        assertEquals("attribute name: name500", event.getStringAttribute("_error_attribute_size_exceed"));
+        assertEquals(Event.ErrorCode.ATTRIBUTE_SIZE_EXCEED,
+            event.getAttributes().get(Event.ReservedAttribute.ERROR_CODE));
+        assertEquals("attribute name: name500", event.getStringAttribute(Event.ReservedAttribute.ERROR_MESSAGE));
     }
 
     /**
@@ -185,7 +189,7 @@ public class EventRecorderTest {
         }
         assertEquals("value500", event.getStringAttribute("name"));
         Assert.assertEquals(1, event.getCurrentNumOfAttributes());
-        assertFalse(event.hasAttribute("_error_attribute_size_exceed"));
+        assertFalse(event.hasAttribute(Event.ReservedAttribute.ERROR_CODE));
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. add error codes consistent with Web SDK
2. add `_clickstream_error` preset event, when event name, global/user attribute is invalid.

*How did you test these changes?*
added test case for each error code and clickstream error event.

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update), [PR link](https://github.com/awslabs/clickstream-analytics-on-aws/pull/208)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.