### PR TITLE
feat: add preset attributes screen name and screen unique id

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AnalyticsEvent.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AnalyticsEvent.java
@@ -482,6 +482,17 @@ public class AnalyticsEvent implements JSONSerializable {
             }
         }
 
+        String screenName = ScreenRefererTool.getCurrentScreenName();
+        String screenUniqueId = ScreenRefererTool.getCurrentScreenUniqueId();
+        if (screenName != null) {
+            try {
+                attributes.put(Event.ReservedAttribute.SCREEN_NAME, screenName);
+                attributes.put(Event.ReservedAttribute.SCREEN_UNIQUE_ID, screenUniqueId);
+            } catch (final JSONException jsonException) {
+                LOG.error("Error serializing session information " + jsonException.getMessage());
+            }
+        }
+
         // ****************************************************
         // ====SDK Details Attributes -- Prefix with 'sdk_'====
         // ****************************************************

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -97,9 +97,7 @@ public class AutoRecordEventClient {
             this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.SCREEN_VIEW);
         long currentTimestamp = event.getEventTimestamp();
         startEngageTimestamp = currentTimestamp;
-        event.addAttribute(Event.ReservedAttribute.SCREEN_NAME, ScreenRefererTool.getCurrentScreenName());
         event.addAttribute(Event.ReservedAttribute.SCREEN_ID, ScreenRefererTool.getCurrentScreenId());
-        event.addAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID, ScreenRefererTool.getCurrentScreenUniqueId());
         event.addAttribute(Event.ReservedAttribute.PREVIOUS_SCREEN_NAME, ScreenRefererTool.getPreviousScreenName());
         event.addAttribute(Event.ReservedAttribute.PREVIOUS_SCREEN_ID, ScreenRefererTool.getPreviousScreenId());
         event.addAttribute(Event.ReservedAttribute.PREVIOUS_SCREEN_UNIQUE_ID,
@@ -138,9 +136,6 @@ public class AutoRecordEventClient {
             final AnalyticsEvent event =
                 this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.USER_ENGAGEMENT);
             event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP, lastEngageTime);
-            event.addAttribute(Event.ReservedAttribute.SCREEN_NAME, ScreenRefererTool.getCurrentScreenName());
-            event.addAttribute(Event.ReservedAttribute.SCREEN_ID, ScreenRefererTool.getCurrentScreenId());
-            event.addAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID, ScreenRefererTool.getCurrentScreenUniqueId());
             this.clickstreamContext.getAnalyticsClient().recordEvent(event);
         }
     }
@@ -222,9 +217,6 @@ public class AutoRecordEventClient {
         final AnalyticsEvent event =
             this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.APP_START);
         event.addAttribute(Event.ReservedAttribute.IS_FIRST_TIME, isFirstTime);
-        event.addAttribute(Event.ReservedAttribute.SCREEN_NAME, ScreenRefererTool.getCurrentScreenName());
-        event.addAttribute(Event.ReservedAttribute.SCREEN_ID, ScreenRefererTool.getCurrentScreenId());
-        event.addAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID, ScreenRefererTool.getCurrentScreenUniqueId());
         this.clickstreamContext.getAnalyticsClient().recordEvent(event);
         isFirstTime = false;
     }
@@ -235,9 +227,6 @@ public class AutoRecordEventClient {
     public void handleAppEnd() {
         final AnalyticsEvent event =
             this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.APP_END);
-        event.addAttribute(Event.ReservedAttribute.SCREEN_NAME, ScreenRefererTool.getCurrentScreenName());
-        event.addAttribute(Event.ReservedAttribute.SCREEN_ID, ScreenRefererTool.getCurrentScreenId());
-        event.addAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID, ScreenRefererTool.getCurrentScreenUniqueId());
         this.clickstreamContext.getAnalyticsClient().recordEvent(event);
     }
 

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -637,9 +637,9 @@ public class AutoRecordEventClientTest {
             JSONObject appStart2 = eventList.get(3).getJSONObject("attributes");
             assertFalse(appStart2.getBoolean(Event.ReservedAttribute.IS_FIRST_TIME));
             assertTrue(appStart2.has(ReservedAttribute.SCREEN_NAME));
-            assertTrue(appStart2.has(Event.ReservedAttribute.SCREEN_ID));
+            assertTrue(appStart2.has(ReservedAttribute.SCREEN_UNIQUE_ID));
             assertEquals(activity1.getClass().getSimpleName(), appStart2.getString(ReservedAttribute.SCREEN_NAME));
-            assertEquals(activity1.getClass().getCanonicalName(), appStart2.getString(ReservedAttribute.SCREEN_ID));
+            assertEquals(String.valueOf(activity1.hashCode()), appStart2.getString(ReservedAttribute.SCREEN_UNIQUE_ID));
         }
     }
 
@@ -664,7 +664,6 @@ public class AutoRecordEventClientTest {
             JSONObject attributes = jsonObject.getJSONObject("attributes");
             assertEquals(Event.PresetEvent.APP_END, eventType);
             assertTrue(attributes.has(ReservedAttribute.SCREEN_NAME));
-            assertTrue(attributes.has(ReservedAttribute.SCREEN_ID));
             assertTrue(attributes.has(ReservedAttribute.SCREEN_UNIQUE_ID));
         }
     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. add `_screen_name` and `_screen_unique_id` as preset attributes

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [x] Yes (Please include a PR link for the documentation update), [PR link](https://github.com/awslabs/clickstream-analytics-on-aws/pull/208)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.