### PR TITLE
ci: support automatically creating github release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Feature
+      labels:
+        - enhancement
+    - title: Fix
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,14 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0
-          token : ${{ secrets.PROJECT_TOKEN }}
+          token: ${{ secrets.PROJECT_TOKEN }}
       - name: Modify for next release
         run: |
           chmod +x release.sh
@@ -27,3 +29,18 @@ jobs:
           git add .
           git commit -m 'release: clickstream Android ${{ env.NEW_VERSION }}'
           git push
+          git tag v${{ env.NEW_VERSION }}
+          git push origin v${{ env.NEW_VERSION }}
+      - name: Assemble release
+        run: |
+          chmod +x gradlew
+          ./gradlew assembleRelease
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "Clickstream Android ${{ env.NEW_VERSION }}"
+          files: |
+            clickstream/build/outputs/aar/clickstream-release.aar
+          tag_name: "v${{ env.NEW_VERSION }}"
+          prerelease: true
+          generate_release_notes: true


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. support automatically creating github release

*How did you test these changes?*
tested by GitHub [action](https://github.com/awslabs/clickstream-android/actions/runs/6194844318/job/16818543142)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.