### PR TITLE
fix: create event error when event name is invalid

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/AWSClickstreamPlugin.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/AWSClickstreamPlugin.java
@@ -90,7 +90,9 @@ public final class AWSClickstreamPlugin extends AnalyticsPlugin<Object> {
     @Override
     public void recordEvent(@NonNull String eventName) {
         final AnalyticsEvent event = analyticsClient.createEvent(eventName);
-        analyticsClient.recordEvent(event);
+        if (event != null) {
+            analyticsClient.recordEvent(event);
+        }
     }
 
     @Override

--- a/clickstream/src/test/java/software/aws/solution/clickstream/IntegrationTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/IntegrationTest.java
@@ -131,6 +131,26 @@ public class IntegrationTest {
     }
 
     /**
+     * test record event with invalid name.
+     *
+     * @throws Exception exception
+     */
+    @Test
+    public void testRecordEventWithInvalidName() throws Exception {
+        executeBackground();
+        ClickstreamAnalytics.recordEvent("01TestEvent");
+        try (Cursor cursor = dbUtil.queryAllEvents()) {
+            cursor.moveToFirst();
+            String eventString = cursor.getString(2);
+            JSONObject jsonObject = new JSONObject(eventString);
+            assertEquals(Event.PresetEvent.CLICKSTREAM_ERROR, jsonObject.getString("event_type"));
+        }
+        assertEquals(1, dbUtil.getTotalNumber());
+        Thread.sleep(1500);
+        assertEquals(0, dbUtil.getTotalNumber());
+    }
+
+    /**
      * test record one AnalyticsEvent use ClickstreamAnalytics api and
      * make sure the event data is valid from db.
      *


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. create event error when  event name is invalid

*How did you test these changes?*
added test case for record an event with invalid event name.

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.