### PR TITLE
fix: remove the engagement time attribute in first screen view

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
@@ -83,7 +83,7 @@ final class ActivityLifecycleManager implements Application.ActivityLifecycleCal
         boolean isSameScreen =
             ScreenRefererTool.isSameScreen(activity.getClass().getCanonicalName(), activity.getClass().getSimpleName(),
                 autoRecordEventClient.getScreenUniqueId(activity));
-        if (!isSameScreen) {
+        if (ScreenRefererTool.getCurrentScreenName() != null && !isSameScreen) {
             autoRecordEventClient.recordUserEngagement();
         }
         autoRecordEventClient.recordViewScreen(activity);
@@ -96,7 +96,6 @@ final class ActivityLifecycleManager implements Application.ActivityLifecycleCal
         // resumed if app regains focus.In either case, app foreground status does not change for the
         // purpose of session tracking.
         LOG.debug("Activity paused: " + activity.getLocalClassName());
-        autoRecordEventClient.updateEndEngageTimestamp();
     }
 
     @Override

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -107,7 +107,9 @@ public class AutoRecordEventClient {
             event.addAttribute(Event.ReservedAttribute.PREVIOUS_TIMESTAMP, lastScreenViewEventTimestamp);
         }
         event.addAttribute(Event.ReservedAttribute.ENTRANCES, isEntrances ? 1 : 0);
-        event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP, lastEngageTime);
+        if (lastEngageTime > 0) {
+            event.addAttribute(Event.ReservedAttribute.ENGAGEMENT_TIMESTAMP, lastEngageTime);
+        }
         this.clickstreamContext.getAnalyticsClient().recordEvent(event);
         PreferencesUtil.savePreviousScreenViewTimestamp(preferences, currentTimestamp);
         isEntrances = false;

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -33,7 +33,6 @@ public class AutoRecordEventClient {
      */
     private static final Log LOG = LogFactory.getLog(AutoRecordEventClient.class);
     private static final int MIN_ENGAGEMENT_TIME = 1000;
-    private static final int DEVICE_ID_CLIP_LENGTH = 8;
     /**
      * The context object wraps all the essential information from the app
      * that are required.
@@ -56,7 +55,6 @@ public class AutoRecordEventClient {
     private boolean isEntrances;
 
     private long startEngageTimestamp;
-    private long endEngageTimestamp;
     private long lastEngageTime;
     private final AndroidPreferences preferences;
 
@@ -132,7 +130,10 @@ public class AutoRecordEventClient {
      * record user engagement event.
      */
     public void recordUserEngagement() {
-        lastEngageTime = endEngageTimestamp - startEngageTimestamp;
+        if (startEngageTimestamp == 0) {
+            return;
+        }
+        lastEngageTime = System.currentTimeMillis() - startEngageTimestamp;
         if (clickstreamContext.getClickstreamConfiguration().isTrackUserEngagementEvents() &&
             lastEngageTime > MIN_ENGAGEMENT_TIME) {
             final AnalyticsEvent event =
@@ -154,13 +155,6 @@ public class AutoRecordEventClient {
      */
     public void updateStartEngageTimestamp() {
         startEngageTimestamp = System.currentTimeMillis();
-    }
-
-    /**
-     * update end engage timestamp.
-     */
-    public void updateEndEngageTimestamp() {
-        endEngageTimestamp = System.currentTimeMillis();
     }
 
     /**

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -198,7 +198,7 @@ public class AutoRecordEventClientTest {
                     Assert.assertFalse(attributes.has(ReservedAttribute.PREVIOUS_SCREEN_NAME));
                     Assert.assertFalse(attributes.has(ReservedAttribute.PREVIOUS_SCREEN_ID));
                     Assert.assertEquals(1, attributes.getInt(ReservedAttribute.ENTRANCES));
-                    Assert.assertTrue(attributes.has(ReservedAttribute.ENGAGEMENT_TIMESTAMP));
+                    Assert.assertFalse(attributes.has(ReservedAttribute.ENGAGEMENT_TIMESTAMP));
                     Assert.assertFalse(attributes.has(ReservedAttribute.PREVIOUS_TIMESTAMP));
                 }
             }

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -103,7 +103,6 @@ public class AutoRecordEventClientTest {
     public void testUserEngagementSuccess() throws Exception {
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
         Thread.sleep(1100);
-        client.updateEndEngageTimestamp();
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
         try (Cursor cursor = dbUtil.queryAllEvents()) {
             List<String> eventList = new ArrayList<>();
@@ -350,7 +349,8 @@ public class AutoRecordEventClientTest {
         callbacks.onActivityResumed(activityA);
         Thread.sleep(200);
         callbacks.onActivityPaused(activityA);
-
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
         callbacks.onActivityCreated(activityA, bundle);
         callbacks.onActivityStarted(activityA);
         callbacks.onActivityResumed(activityA);
@@ -700,7 +700,10 @@ public class AutoRecordEventClientTest {
     @After
     public void tearDown() {
         ScreenRefererTool.setCurrentScreenName(null);
+        ScreenRefererTool.setCurrentScreenName(null);
         ScreenRefererTool.setCurrentScreenId(null);
+        ScreenRefererTool.setCurrentScreenId(null);
+        ScreenRefererTool.setCurrentScreenUniqueId(null);
         ScreenRefererTool.setCurrentScreenUniqueId(null);
         dbUtil.closeDB();
     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. remove the negative `_engagement_time_msec` value in first screen view event

*How did you test these changes?*
assert the first screen view event does not have the attribute `_engagement_time_msec`

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.