### PR TITLE
fix: engagement time in first screen view when app warm starts

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -158,6 +158,13 @@ public class AutoRecordEventClient {
     }
 
     /**
+     * reset last engagement time when app warm start.
+     */
+    public void resetLastEngageTime() {
+        lastEngageTime = 0;
+    }
+
+    /**
      * check and record _app_update event.
      */
     private void checkAppVersionUpdate() {

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -450,6 +450,41 @@ public class AutoRecordEventClientTest {
         }
     }
 
+    /**
+     * test app warm start without engagement_mesc attribute.
+     *
+     * @throws Exception exception.
+     */
+    @Test
+    public void testAppWarmStartWithoutEngagementTime() throws Exception {
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+        Activity activityA = mock(ActivityA.class);
+
+        Bundle bundle = mock(Bundle.class);
+        callbacks.onActivityCreated(activityA, bundle);
+        callbacks.onActivityStarted(activityA);
+        callbacks.onActivityResumed(activityA);
+        callbacks.onActivityPaused(activityA);
+        callbacks.onActivityDestroyed(activityA);
+
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+
+        Activity activityA1 = mock(ActivityA.class);
+        callbacks.onActivityCreated(activityA1, bundle);
+        callbacks.onActivityStarted(activityA1);
+        callbacks.onActivityResumed(activityA1);
+
+        try (Cursor cursor = dbUtil.queryAllEvents()) {
+            cursor.moveToLast();
+            String eventString = cursor.getString(2);
+            JSONObject jsonObject = new JSONObject(eventString);
+            String eventName = jsonObject.getString("event_type");
+            assertEquals(Event.PresetEvent.SCREEN_VIEW, eventName);
+            JSONObject attributes = jsonObject.getJSONObject("attributes");
+            Assert.assertFalse(attributes.has(ReservedAttribute.ENGAGEMENT_TIMESTAMP));
+        }
+    }
 
     /**
      * test app version not update.


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. fix engagement time in first screen view when app warm starts

*How did you test these changes?*
added test case to simulation the app warm start and verify `_engagement_mesc` attribute not in the first screen view event.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.