### PR TITLE
feat: add session attributes in _first_open event

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/SessionClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/SessionClient.java
@@ -46,6 +46,8 @@ public class SessionClient {
             throw new IllegalArgumentException("A valid AnalyticsClient must be provided!");
         }
         this.clickstreamContext = clickstreamContext;
+        session = Session.getInstance(clickstreamContext);
+        this.clickstreamContext.getAnalyticsClient().setSession(session);
     }
 
     /**

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -615,6 +615,11 @@ public class AutoRecordEventClientTest {
         JSONObject jsonObject = new JSONObject(eventString);
         String eventType = jsonObject.getString("event_type");
         assertEquals(Event.PresetEvent.FIRST_OPEN, eventType);
+        JSONObject attributes = jsonObject.getJSONObject("attributes");
+        assertNotNull(attributes.getString("_session_id"));
+        assertNotNull(attributes.getString("_session_start_timestamp"));
+        assertNotNull(attributes.getString("_session_duration"));
+        assertNotNull(attributes.getString("_session_number"));
         cursor.close();
     }
 

--- a/clickstream/src/test/java/software/aws/solution/clickstream/EventRecorderTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/EventRecorderTest.java
@@ -211,7 +211,7 @@ public class EventRecorderTest {
         Cursor cursor = dbUtil.queryAllEvents();
         String[] result = getBatchOfEvents(cursor);
         assertEquals(result.length, 2);
-        assertEquals("[" + event.toJSONObject().toString() + "]", result[0]);
+        assertTrue(result[0].contains(event.getEventId()));
         assertEquals("1", result[1]);
         cursor.close();
     }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. add session attributes in _first_open event

*How did you test these changes?*
test by asset session related attributes in the _first_open event.

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.