### PR TITLE
fix: filter two consecutive identical scree view events

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
@@ -83,9 +83,8 @@ final class ActivityLifecycleManager implements Application.ActivityLifecycleCal
         // An activity came to foreground. Application potentially entered foreground as well
         // if there were no other activities in the foreground.
         LOG.debug("Activity resumed: " + activity.getLocalClassName());
-        boolean isSameScreen =
-            ScreenRefererTool.isSameScreen(activity.getClass().getCanonicalName(), activity.getClass().getSimpleName(),
-                autoRecordEventClient.getScreenUniqueId(activity));
+        boolean isSameScreen = ScreenRefererTool.isSameScreen(activity.getClass().getSimpleName(),
+            autoRecordEventClient.getScreenUniqueId(activity));
         if (ScreenRefererTool.getCurrentScreenName() != null && !isSameScreen) {
             if (!isFromForeground) {
                 autoRecordEventClient.recordUserEngagement();
@@ -99,6 +98,7 @@ final class ActivityLifecycleManager implements Application.ActivityLifecycleCal
 
     /**
      * Handle Screen View triggered manually.
+     *
      * @param event the screen view event
      */
     public void onScreenViewManually(AnalyticsEvent event) {

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -85,7 +85,7 @@ public class AutoRecordEventClient {
         String screenId = activity.getClass().getCanonicalName();
         String screenName = activity.getClass().getSimpleName();
         String screenUniqueId = getScreenUniqueId(activity);
-        if (ScreenRefererTool.isSameScreen(screenId, screenName, screenUniqueId)) {
+        if (ScreenRefererTool.isSameScreen(screenName, screenUniqueId)) {
             return;
         }
         ScreenRefererTool.setCurrentScreenId(screenId);
@@ -104,11 +104,14 @@ public class AutoRecordEventClient {
     public void recordViewScreenManually(AnalyticsEvent event) {
         String screenName = event.getStringAttribute(Event.ReservedAttribute.SCREEN_NAME);
         if (screenName != null) {
+            String screenUniqueId = event.getStringAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID);
+            if (ScreenRefererTool.isSameScreen(screenName, screenUniqueId)) {
+                return;
+            }
             if (ScreenRefererTool.getCurrentScreenName() != null) {
                 recordUserEngagement();
             }
             ScreenRefererTool.setCurrentScreenName(screenName);
-            String screenUniqueId = event.getStringAttribute(Event.ReservedAttribute.SCREEN_UNIQUE_ID);
             if (screenUniqueId != null) {
                 ScreenRefererTool.setCurrentScreenUniqueId(screenUniqueId);
             }

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/ScreenRefererTool.java
@@ -117,16 +117,13 @@ public final class ScreenRefererTool {
     /**
      * Judging that the current screen is the same as the previous screen.
      *
-     * @param screenId       current screen id
      * @param screenName     current screen name
      * @param screenUniqueId current screen unique id
      * @return the boolean value for is the same screen
      */
-    public static boolean isSameScreen(String screenId, String screenName, String screenUniqueId) {
-        return mCurrentScreenId != null
-            && mCurrentScreenName != null
-            && mCurrentScreenId.equals(screenId)
-            && mCurrentScreenName.equals(screenName)
-            && mCurrentScreenUniqueId.equals(screenUniqueId);
+    public static boolean isSameScreen(String screenName, String screenUniqueId) {
+        return mCurrentScreenName != null &&
+            mCurrentScreenName.equals(screenName) &&
+            (mCurrentScreenUniqueId == null || mCurrentScreenUniqueId.equals(screenUniqueId));
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. filter two consecutive identical scree view events

*How did you test these changes?*
added new test case for two consecutive identical scree view events

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.