### PR TITLE
fix: sessionId in first open and session start events

### DIFF
--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/Session.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/Session.java
@@ -96,22 +96,26 @@ public final class Session {
      * Get the session object from preferences, if exists and not expired return it.
      * otherwise create a new session.
      *
-     * @param context The {@link ClickstreamContext}.
+     * @param context         The {@link ClickstreamContext}.
+     * @param previousSession The previous session for check whether is new session.
      * @return new Session object.
      */
-    public static Session getInstance(final ClickstreamContext context) {
-        // get session from preference
-        Session storedSession = PreferencesUtil.getSession(context.getSystem().getPreferences());
-        int sessionIndex = 1;
-        if (storedSession != null) {
-            if (System.currentTimeMillis() - storedSession.getPauseTime() <
-                context.getClickstreamConfiguration().getSessionTimeoutDuration()) {
-                return storedSession;
-            } else {
-                sessionIndex = storedSession.sessionIndex + 1;
-            }
+    public static Session getInstance(final ClickstreamContext context, Session previousSession) {
+        Session session = previousSession;
+        if (session == null) {
+            session = PreferencesUtil.getSession(context.getSystem().getPreferences());
         }
-        return new Session(context, sessionIndex);
+        if (session != null) {
+            if (session.getPauseTime() == null ||
+                System.currentTimeMillis() - session.getPauseTime() <
+                    context.getClickstreamConfiguration().getSessionTimeoutDuration()) {
+                return session;
+            } else {
+                return new Session(context, session.getSessionIndex() + 1);
+            }
+        } else {
+            return new Session(context, 1);
+        }
     }
 
     /**

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/SessionClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/SessionClient.java
@@ -46,7 +46,7 @@ public class SessionClient {
             throw new IllegalArgumentException("A valid AnalyticsClient must be provided!");
         }
         this.clickstreamContext = clickstreamContext;
-        session = Session.getInstance(clickstreamContext);
+        session = Session.getInstance(clickstreamContext, null);
         this.clickstreamContext.getAnalyticsClient().setSession(session);
     }
 
@@ -58,7 +58,7 @@ public class SessionClient {
      * @return is new session.
      */
     public synchronized boolean initialSession() {
-        session = Session.getInstance(clickstreamContext);
+        session = Session.getInstance(clickstreamContext, session);
         this.clickstreamContext.getAnalyticsClient().setSession(session);
         if (session.isNewSession()) {
             final AnalyticsEvent event =

--- a/clickstream/src/test/java/software/aws/solution/clickstream/db/DBUtilTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/db/DBUtilTest.java
@@ -116,8 +116,9 @@ public class DBUtilTest {
     @Test
     public void testGetTotalDbSize() {
         AnalyticsEvent analyticsEvent = AnalyticsEventTest.getAnalyticsClient().createEvent("testEvent");
-        int eventLength = analyticsEvent.toJSONObject().toString().length();
+        int eventLength1 = analyticsEvent.toJSONObject().toString().length();
         Uri uri1 = dbUtil.saveEvent(analyticsEvent);
+        int eventLength2 = analyticsEvent.toJSONObject().toString().length();
         Uri uri2 = dbUtil.saveEvent(analyticsEvent);
         int idInserted1 = Integer.parseInt(uri1.getLastPathSegment());
         int idInserted2 = Integer.parseInt(uri2.getLastPathSegment());
@@ -127,7 +128,7 @@ public class DBUtilTest {
         assertNotNull(c);
         assertEquals(c.getCount(), 2);
         c.close();
-        Assert.assertEquals(dbUtil.getTotalSize(), eventLength * 2);
+        Assert.assertEquals(dbUtil.getTotalSize(), eventLength1 + eventLength2);
     }
 
     /**


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. fix sessionId in first open and session start events

*How did you test these changes?*
added test case for assert first open and session start event have the same sessionid

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.