### PR TITLE
fix: the second app start event's sessionId

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -29,7 +29,6 @@ jobs:
           cache: gradle
       - name: Build SDK release aar file
         run: |
-          echo ${{ github.event.pull_request.title }}
           chmod +x gradlew
           ./gradlew assembleRelease
       - name: Set up JDK 17

--- a/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/ActivityLifecycleManager.java
@@ -149,10 +149,11 @@ final class ActivityLifecycleManager implements Application.ActivityLifecycleCal
         } else if (event == Lifecycle.Event.ON_START) {
             LOG.debug("Application entered the foreground.");
             isFromForeground = true;
+            boolean isNewSession = sessionClient.initialSession();
             autoRecordEventClient.handleAppStart();
             autoRecordEventClient.updateStartEngageTimestamp();
-            boolean isNewSession = sessionClient.initialSession();
             if (isNewSession) {
+                autoRecordEventClient.handleSessionStart();
                 autoRecordEventClient.setIsEntrances();
                 recordScreenViewAfterSessionStart();
             }

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/AutoRecordEventClient.java
@@ -260,6 +260,15 @@ public class AutoRecordEventClient {
     }
 
     /**
+     * handle session start events.
+     */
+    public void handleSessionStart() {
+        final AnalyticsEvent event =
+            this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.SESSION_START);
+        this.clickstreamContext.getAnalyticsClient().recordEvent(event);
+    }
+
+    /**
      * handle the app end event.
      */
     public void handleAppEnd() {

--- a/clickstream/src/main/java/software/aws/solution/clickstream/client/SessionClient.java
+++ b/clickstream/src/main/java/software/aws/solution/clickstream/client/SessionClient.java
@@ -60,11 +60,6 @@ public class SessionClient {
     public synchronized boolean initialSession() {
         session = Session.getInstance(clickstreamContext, session);
         this.clickstreamContext.getAnalyticsClient().setSession(session);
-        if (session.isNewSession()) {
-            final AnalyticsEvent event =
-                this.clickstreamContext.getAnalyticsClient().createEvent(Event.PresetEvent.SESSION_START);
-            this.clickstreamContext.getAnalyticsClient().recordEvent(event);
-        }
         return session.isNewSession();
     }
 

--- a/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
+++ b/clickstream/src/test/java/software/aws/solution/clickstream/AutoRecordEventClientTest.java
@@ -1019,6 +1019,15 @@ public class AutoRecordEventClientTest {
             JSONObject jsonObject2 = new JSONObject(eventString2);
             String eventName2 = jsonObject2.getString("event_type");
             assertEquals(Event.PresetEvent.SESSION_START, eventName2);
+
+            // assert that the second app start event will have the same session id
+            cursor.moveToPrevious();
+            String eventString3 = cursor.getString(2);
+            JSONObject jsonObject3 = new JSONObject(eventString3);
+            String eventName3 = jsonObject3.getString("event_type");
+            assertEquals(Event.PresetEvent.APP_START, eventName3);
+            assertEquals(jsonObject3.getJSONObject("attributes").getString("_session_id"),
+                jsonObject2.getJSONObject("attributes").getString("_session_id"));
         }
     }
 


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. fix the second _app_start event's sessionId

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [x] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.