### PR TITLE
chore: bump amplify-core to the latest version v1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
     minSdkVersion = 16
     targetSdkVersion = 30
     awsSdkVersion = '2.51.0'
-    amplifySdkVersion = '1.37.2'
+    amplifySdkVersion = '1.38.8'
     lifecycleVersion = "2.6.1"
     dependency = [
         android: [


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/awslabs/clickstream-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Description of changes:*
1. bump amplify to the latest version v1.x and  the new version removed the dependency of `com.google.android.play:core` which will solve the issue of Google Play's SDK version requirements.

*How did you test these changes?*
(Please add a line here how the changes were tested)

*Documentation update required?*
- [ ] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.